### PR TITLE
Add a method to pad addresses smaller than 32 bytes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitgo-utxo-lib",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "engines": {
@@ -12,6 +12,7 @@
     "bitcoinjs",
     "bitcoin",
     "zcash",
+    "dash",
     "browserify",
     "javascript"
   ],

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -112,6 +112,24 @@ ECPair.prototype.getPublicKeyBuffer = function () {
   return this.Q.getEncoded(this.compressed)
 }
 
+/**
+ * Get the private key as a 32 bytes buffer. If it is smaller than 32 bytes, pad it with zeros
+ * @return Buffer
+ */
+ECPair.prototype.getPrivateKeyBuffer = function () {
+  if (!this.d) throw new Error('Missing private key')
+
+  var bigIntBuffer = this.d.toBuffer()
+  if (bigIntBuffer.length > 32) throw new Error('Private key size exceeds 32 bytes')
+
+  if (bigIntBuffer.length === 32) {
+    return bigIntBuffer
+  }
+  var newBuffer = Buffer.alloc(32)
+  bigIntBuffer.copy(newBuffer, newBuffer.length - bigIntBuffer.length, 0, bigIntBuffer.length)
+  return newBuffer
+}
+
 ECPair.prototype.sign = function (hash) {
   if (!this.d) throw new Error('Missing private key')
 

--- a/test/ecpair.js
+++ b/test/ecpair.js
@@ -82,6 +82,31 @@ describe('ECPair', function () {
     }))
   })
 
+  describe('getPrivateKeyBuffer', function () {
+    it('pads short private keys', sinon.test(function () {
+      var keyPair = new ECPair(BigInteger.ONE)
+      assert.strictEqual(keyPair.getPrivateKeyBuffer().byteLength, 32)
+      assert.strictEqual(keyPair.getPrivateKeyBuffer().toString('hex'),
+        '0000000000000000000000000000000000000000000000000000000000000001')
+    }))
+
+    it('does not pad 32 bytes private keys', sinon.test(function () {
+      var hexString = 'a000000000000000000000000000000000000000000000000000000000000000'
+      var keyPair = new ECPair(new BigInteger(hexString, 16))
+      assert.strictEqual(keyPair.getPrivateKeyBuffer().byteLength, 32)
+      assert.strictEqual(keyPair.getPrivateKeyBuffer().toString('hex'), hexString)
+    }))
+
+    it('throws if the key is too long', sinon.test(function () {
+      var hexString = '10000000000000000000000000000000000000000000000000000000000000000'
+
+      assert.throws(function () {
+        var keyPair = new ECPair(new BigInteger(hexString, 16))
+        keyPair.getPrivateKeyBuffer()
+      }, new RegExp('Private key must be less than the curve order'))
+    }))
+  })
+
   describe('fromWIF', function () {
     fixtures.valid.forEach(function (f) {
       it('imports ' + f.WIF + ' (' + f.network + ')', function () {


### PR DESCRIPTION
This is a non invasive change to add a method to deal with private keys smaller than 32 bytes. If we change the d.get method directly or toHex(), we would roll out this change without any ability to measure it's impact.