### PR TITLE
add a bech32 prefix for bitcoin gold

### DIFF
--- a/src/networks.js
+++ b/src/networks.js
@@ -78,6 +78,7 @@ module.exports = {
   },
   bitcoingold: {
     messagePrefix: '\x18Bitcoin Gold Signed Message:\n',
+    bech32: 'btg',
     bip32: {
       public: 0x0488b21e,
       private: 0x0488ade4


### PR DESCRIPTION
`btg` is the prefix defined by [slip-0173](https://github.com/satoshilabs/slips/blob/master/slip-0173.md) and used in [the official bitcoinjs-lib fork](https://github.com/BTCGPU/bitcoinjs-lib/blob/master/src/networks.js#L7)