### PR TITLE
BG-7253: Upgrade bitgo-utxo-lib version to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitgo-utxo-lib",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "engines": {


### PR DESCRIPTION
Signed-off-by: Tyler Levine <tyler@bitgo.com>