### PR TITLE
BG-8888: Move secp256k1 dependent functions from bitgojs

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
     "sinon": "^1.12.2",
     "standard": "^9.0.2"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "optionalDependencies": {
+    "secp256k1": "^3.5.2"
+  }
 }

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -12,6 +12,8 @@ var BigInteger = require('bigi')
 var ecurve = require('ecurve')
 var secp256k1 = ecdsa.__curve
 
+var fastcurve = require('./fastcurve')
+
 function ECPair (d, Q, options) {
   if (options) {
     typeforce({
@@ -133,6 +135,9 @@ ECPair.prototype.getPrivateKeyBuffer = function () {
 ECPair.prototype.sign = function (hash) {
   if (!this.d) throw new Error('Missing private key')
 
+  var sig = fastcurve.sign(hash, this.d)
+
+  if (sig) return sig
   return ecdsa.sign(hash, this.d)
 }
 
@@ -143,6 +148,8 @@ ECPair.prototype.toWIF = function () {
 }
 
 ECPair.prototype.verify = function (hash, signature) {
+  var fastsig = fastcurve.verify(hash, signature, this.getPublicKeyBuffer())
+  if (fastsig) return fastsig
   return ecdsa.verify(hash, signature, this.Q)
 }
 

--- a/src/fastcurve.js
+++ b/src/fastcurve.js
@@ -1,4 +1,7 @@
+var typeforce = require('typeforce')
+
 var ECSignature = require('./ecsignature')
+var types = require('./types')
 
 var secp256k1
 var available = false
@@ -23,6 +26,8 @@ try {
  * @return {undefined}
  */
 var publicKeyCreate = function (buffer, compressed) {
+  typeforce(types.tuple(types.Buffer256bit, types.Boolean), arguments)
+
   if (!available) {
     return undefined
   }
@@ -31,6 +36,8 @@ var publicKeyCreate = function (buffer, compressed) {
 }
 
 var sign = function (hash, d) {
+  typeforce(types.tuple(types.Buffer256bit, types.BigInt), arguments)
+
   if (!available) {
     return undefined
   }
@@ -40,6 +47,13 @@ var sign = function (hash, d) {
 }
 
 var verify = function (hash, sig, pubkey) {
+  typeforce(types.tuple(
+    types.Hash256bit,
+    types.ECSignature,
+    // both compressed and uncompressed public keys are fine
+    types.oneOf(types.BufferN(33), types.BufferN(65))),
+    arguments)
+
   if (!available) {
     return undefined
   }

--- a/src/fastcurve.js
+++ b/src/fastcurve.js
@@ -1,0 +1,57 @@
+var ECSignature = require('./ecsignature')
+
+var secp256k1
+var available = false
+try {
+  // secp256k1 is an optional native module used for accelerating
+  // low-level elliptic curve operations. It's nice to have, but
+  // we can live without it too
+  secp256k1 = require('secp256k1')
+  available = true
+} catch (e) {
+  // secp256k1 is not available, this is alright
+}
+
+/**
+ * Derive a public key from a 32 byte private key buffer.
+ *
+ * Uses secp256k1 for acceleration. If secp256k1 is not available,
+ * this function returns undefined.
+ *
+ * @param buffer {Buffer} Private key buffer
+ * @param compressed {Boolean} Whether the public key should be compressed
+ * @return {undefined}
+ */
+var publicKeyCreate = function (buffer, compressed) {
+  if (!available) {
+    return undefined
+  }
+
+  return secp256k1.publicKeyCreate(buffer, compressed)
+}
+
+var sign = function (hash, d) {
+  if (!available) {
+    return undefined
+  }
+
+  var sig = secp256k1.sign(hash, d.toBuffer(32)).signature
+  return ECSignature.fromDER(secp256k1.signatureExport(sig))
+}
+
+var verify = function (hash, sig, pubkey) {
+  if (!available) {
+    return undefined
+  }
+
+  sig = new ECSignature(sig.r, sig.s)
+  sig = secp256k1.signatureNormalize(secp256k1.signatureImport(sig.toDER()))
+  return secp256k1.verify(hash, sig, pubkey)
+}
+
+module.exports = {
+  available: available,
+  publicKeyCreate: publicKeyCreate,
+  sign: sign,
+  verify: verify
+}

--- a/src/fastcurve.js
+++ b/src/fastcurve.js
@@ -35,6 +35,16 @@ var publicKeyCreate = function (buffer, compressed) {
   return secp256k1.publicKeyCreate(buffer, compressed)
 }
 
+/**
+ * Create an ECDSA signature over the given message hash `hash` with
+ * the private key `d`.
+ *
+ * Uses secp256k1 for acceleration. If secp256k1 is not available,
+ * this function returns undefined.
+ * @param hash {Buffer} hash of the message which is to be signed
+ * @param d {BigInteger} private key which is to be used for signing
+ * @return {ECSignature}
+ */
 var sign = function (hash, d) {
   typeforce(types.tuple(types.Buffer256bit, types.BigInt), arguments)
 
@@ -46,6 +56,17 @@ var sign = function (hash, d) {
   return ECSignature.fromDER(secp256k1.signatureExport(sig))
 }
 
+/**
+ * Verify an ECDSA signature over the given message hash `hash` with signature `sig`
+ * and public key `pubkey`.
+ *
+ * Uses secp256k1 for acceleration. If secp256k1 is not available,
+ * this function returns undefined.
+ * @param hash {Buffer} hash of the message which is to be verified
+ * @param sig {ECSignature} signature which is to be verified
+ * @param pubkey {Buffer} public key which will be used to verify the message signature
+ * @return {Boolean}
+ */
 var verify = function (hash, sig, pubkey) {
   typeforce(types.tuple(
     types.Hash256bit,

--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -338,7 +338,7 @@ HDNode.prototype.derivePath = function (path, cache) {
  * Uses secp256k1 if available for accelerated computation of the cloned public key.
  * @return {ECPair}
  */
-HDNode.prototype.cloneKeypair = function() {
+HDNode.prototype.cloneKeypair = function () {
   typeforce(types.maybe(types.Network), arguments)
   var k = this.keyPair
   var result = new ECPair(k.d, k.d ? null : k.Q, {

--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -12,6 +12,8 @@ var ECPair = require('./ecpair')
 var ecurve = require('ecurve')
 var curve = ecurve.getCurveByName('secp256k1')
 
+var fastcurve = require('./fastcurve')
+
 function HDNode (keyPair, chainCode) {
   typeforce(types.tuple('ECPair', types.Buffer256bit), arguments)
 
@@ -22,6 +24,7 @@ function HDNode (keyPair, chainCode) {
   this.depth = 0
   this.index = 0
   this.parentFingerprint = 0x00000000
+  this.derivationCache = {}
 }
 
 HDNode.HIGHEST_BIT = 0x80000000
@@ -256,7 +259,10 @@ HDNode.prototype.derive = function (index) {
   } else {
     // Ki = point(parse256(IL)) + Kpar
     //    = G*IL + Kpar
-    var Ki = curve.G.multiply(pIL).add(this.keyPair.Q)
+    var point = fastcurve.publicKeyCreate(IL, false)
+    var Ki = point
+      ? ecurve.Point.decodeFrom(curve, point).add(this.keyPair.Q)
+      : curve.G.multiply(pIL).add(this.keyPair.Q)
 
     // In case Ki is the point at infinity, proceed with the next value for i
     if (curve.isInfinity(Ki)) {
@@ -289,8 +295,11 @@ HDNode.prototype.isNeutered = function () {
   return !(this.keyPair.d)
 }
 
-HDNode.prototype.derivePath = function (path) {
+HDNode.prototype.derivePath = function (path, cache) {
   typeforce(types.BIP32Path, path)
+  typeforce(types.maybe(types.Object), cache)
+
+  cache = cache || this.derivationCache
 
   var splitPath = path.split('/')
   if (splitPath[0] === 'm') {
@@ -303,14 +312,48 @@ HDNode.prototype.derivePath = function (path) {
 
   return splitPath.reduce(function (prevHd, indexStr) {
     var index
+    var cacheObject = cache[indexStr] || {}
+    if (cacheObject.node) {
+      cache = cacheObject.next
+      return cacheObject.node
+    }
     if (indexStr.slice(-1) === "'") {
       index = parseInt(indexStr.slice(0, -1), 10)
-      return prevHd.deriveHardened(index)
+      cacheObject.node = prevHd.deriveHardened(index)
     } else {
       index = parseInt(indexStr, 10)
-      return prevHd.derive(index)
+      cacheObject.node = prevHd.derive(index)
     }
+
+    cache[indexStr] = cacheObject
+    cacheObject.next = {}
+    cache = cacheObject.next
+    return cacheObject.node
   }, this)
+}
+
+/**
+ * Create a new ECPair object from this HDNode's ECPair.
+ *
+ * Uses secp256k1 if available for accelerated computation of the cloned public key.
+ * @return {ECPair}
+ */
+HDNode.prototype.cloneKeypair = function() {
+  typeforce(types.maybe(types.Network), arguments)
+  var k = this.keyPair
+  var result = new ECPair(k.d, k.d ? null : k.Q, {
+    network: k.network,
+    compressed: k.compressed
+  })
+  // Creating Q from d takes ~25ms, so if it's not created, use native bindings to pre-compute
+  // if Q is not set here, it will be lazily computed via the slow path
+  if (!result.__Q) {
+    var point = fastcurve.publicKeyCreate(k.d.toBuffer(32), false)
+    if (point) {
+      result.__Q = ecurve.Point.decodeFrom(curve, point)
+    }
+  }
+  return result
 }
 
 module.exports = HDNode

--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -339,7 +339,6 @@ HDNode.prototype.derivePath = function (path, cache) {
  * @return {ECPair}
  */
 HDNode.prototype.cloneKeypair = function () {
-  typeforce(types.maybe(types.Network), arguments)
   var k = this.keyPair
   var result = new ECPair(k.d, k.d ? null : k.Q, {
     network: k.network,

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -806,7 +806,7 @@ TransactionBuilder.prototype.sign = function (vin, keyPair, redeemScript, hashTy
   } else {
     if (input.witness) {
       signatureHash = this.tx.hashForWitnessV0(vin, input.signScript, witnessValue, hashType)
-      debug('Calculated witnessv0 sighash (%s)', signatureHash)
+      debug('Calculated witnessv0 sighash (%s)', signatureHash.toString('hex'))
     } else {
       signatureHash = this.tx.hashForSignature(vin, input.signScript, hashType)
       debug('Calculated sighash (%s)', signatureHash.toString('hex'))

--- a/test/ecpair.js
+++ b/test/ecpair.js
@@ -275,7 +275,7 @@ describe('ECPair', function () {
 
       it('wraps ecdsa.verify', sinon.test(function () {
         this.mock(fastcurve).expects('verify')
-          .once().withArgs(hash, signature, keyPair.getPublicKeyBuffer()).returns(undefined);
+          .once().withArgs(hash, signature, keyPair.getPublicKeyBuffer()).returns(undefined)
         this.mock(ecdsa).expects('verify')
           .once().withArgs(hash, signature, keyPair.Q)
 
@@ -288,7 +288,6 @@ describe('ECPair', function () {
 
         keyPair.verify(hash, signature)
       }))
-
     })
   })
 })

--- a/test/ecpair.js
+++ b/test/ecpair.js
@@ -9,6 +9,7 @@ var sinon = require('sinon')
 
 var BigInteger = require('bigi')
 var ECPair = require('../src/ecpair')
+var fastcurve = require('../src/fastcurve')
 
 var fixtures = require('./fixtures/ecpair.json')
 var curve = ecdsa.__curve
@@ -241,8 +242,17 @@ describe('ECPair', function () {
 
     describe('signing', function () {
       it('wraps ecdsa.sign', sinon.test(function () {
+        this.mock(fastcurve).expects('sign')
+          .once().withArgs(hash, keyPair.d).returns(undefined)
         this.mock(ecdsa).expects('sign')
           .once().withArgs(hash, keyPair.d)
+
+        keyPair.sign(hash)
+      }))
+
+      it('wraps fastcurve.sign', sinon.test(function () {
+        this.mock(fastcurve).expects('sign')
+        .once().withArgs(hash, keyPair.d)
 
         keyPair.sign(hash)
       }))
@@ -264,11 +274,21 @@ describe('ECPair', function () {
       })
 
       it('wraps ecdsa.verify', sinon.test(function () {
+        this.mock(fastcurve).expects('verify')
+          .once().withArgs(hash, signature, keyPair.getPublicKeyBuffer()).returns(undefined);
         this.mock(ecdsa).expects('verify')
           .once().withArgs(hash, signature, keyPair.Q)
 
         keyPair.verify(hash, signature)
       }))
+
+      it('wraps fastcurve.verify', sinon.test(function () {
+        this.mock(fastcurve).expects('verify')
+        .once().withArgs(hash, signature, keyPair.getPublicKeyBuffer())
+
+        keyPair.verify(hash, signature)
+      }))
+
     })
   })
 })

--- a/test/hdnode.js
+++ b/test/hdnode.js
@@ -383,5 +383,17 @@ describe('HDNode', function () {
       var child = hdkey.derivePath('m/44\'/0\'/0\'/0/0\'')
       assert.strictEqual(child.keyPair.d.toBuffer().toString('hex'), '3348069561d2a0fb925e74bf198762acc47dce7db27372257d2d959a9e6f8aeb')
     })
+
+    it('works with cached intermediate nodes', function () {
+      var key = 'xprv9s21ZrQH143K3ckY9DgU79uMTJkQRLdbCCVDh81SnxTgPzLLGax6uHeBULTtaEtcAvKjXfT7ZWtHzKjTpujMkUd9dDb8msDeAfnJxrgAYhr'
+      var hdkey = HDNode.fromBase58(key)
+      assert.strictEqual(hdkey.keyPair.d.toBuffer(32).toString('hex'), '00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd')
+
+      var child0 = hdkey.derivePath('m/44\'/0\'/0\'/0/0\'')
+      var child1 = hdkey.derivePath('m/44\'/0\'/0\'/0/0\'')
+
+      // check for equal object references
+      assert.strictEqual(child0, child1)
+    })
   })
 })

--- a/test/integration/cltv.js
+++ b/test/integration/cltv.js
@@ -34,7 +34,8 @@ describe('bitcoinjs-lib (transactions w/ CLTV)', function () {
   }
 
   // expiry past, {Alice's signature} OP_TRUE
-  it('can create (and broadcast via 3PBP) a Transaction where Alice can redeem the output after the expiry (in the past)', function (done) {
+  // disabled due to the 3rd party blockchain provider (3PBP) being down
+  it.skip('can create (and broadcast via 3PBP) a Transaction where Alice can redeem the output after the expiry (in the past)', function (done) {
     this.timeout(30000)
 
     // 3 hours ago
@@ -75,7 +76,8 @@ describe('bitcoinjs-lib (transactions w/ CLTV)', function () {
   })
 
   // expiry will pass, {Alice's signature} OP_TRUE
-  it('can create (and broadcast via 3PBP) a Transaction where Alice can redeem the output after the expiry (in the future)', function (done) {
+  // disabled due to the 3rd party blockchain provider (3PBP) being down
+  it.skip('can create (and broadcast via 3PBP) a Transaction where Alice can redeem the output after the expiry (in the future)', function (done) {
     this.timeout(30000)
 
     regtestUtils.height(function (err, height) {

--- a/test/integration/transactions.js
+++ b/test/integration/transactions.js
@@ -42,7 +42,8 @@ describe('bitcoinjs-lib (transactions)', function () {
     assert.strictEqual(txb.build().toHex(), '01000000024c94e48a870b85f41228d33cf25213dfcc8dd796e7211ed6b1f9a014809dbbb5060000006a473044022041450c258ce7cac7da97316bf2ea1ce66d88967c4df94f3e91f4c2a30f5d08cb02203674d516e6bb2b0afd084c3551614bd9cec3c2945231245e891b145f2d6951f0012103e05ce435e462ec503143305feb6c00e06a3ad52fbf939e85c65f3a765bb7baacffffffff3077d9de049574c3af9bc9c09a7c9db80f2d94caaf63988c9166249b955e867d000000006b483045022100aeb5f1332c79c446d3f906e4499b2e678500580a3f90329edf1ba502eec9402e022072c8b863f8c8d6c26f4c691ac9a6610aa4200edc697306648ee844cfbc089d7a012103df7940ee7cddd2f97763f67e1fb13488da3fbdd7f9c68ec5ef0864074745a289ffffffff0220bf0200000000001976a9147dd65592d0ab2fe0d0257d571abf032cd9db93dc88ac10980200000000001976a914c42e7ef92fdb603af844d064faad95db9bcdfd3d88ac00000000')
   })
 
-  it('can create (and broadcast via 3PBP) a typical Transaction', function (done) {
+  // disabled due to the 3rd party blockchain provider (3PBP) being down
+  it.skip('can create (and broadcast via 3PBP) a typical Transaction', function (done) {
     this.timeout(30000)
 
     var alice1 = bitcoin.ECPair.makeRandom({ network: regtest })
@@ -74,7 +75,8 @@ describe('bitcoinjs-lib (transactions)', function () {
     })
   })
 
-  it('can create (and broadcast via 3PBP) a Transaction with an OP_RETURN output', function (done) {
+  // disabled due to the 3rd party blockchain provider (3PBP) being down
+  it.skip('can create (and broadcast via 3PBP) a Transaction with an OP_RETURN output', function (done) {
     this.timeout(30000)
 
     var keyPair = bitcoin.ECPair.makeRandom({ network: regtest })
@@ -96,7 +98,8 @@ describe('bitcoinjs-lib (transactions)', function () {
     })
   })
 
-  it('can create (and broadcast via 3PBP) a Transaction with a 2-of-4 P2SH(multisig) input', function (done) {
+  // disabled due to the 3rd party blockchain provider (3PBP) being down
+  it.skip('can create (and broadcast via 3PBP) a Transaction with a 2-of-4 P2SH(multisig) input', function (done) {
     this.timeout(30000)
 
     var keyPairs = [
@@ -136,7 +139,8 @@ describe('bitcoinjs-lib (transactions)', function () {
     })
   })
 
-  it('can create (and broadcast via 3PBP) a Transaction with a SegWit P2SH(P2WPKH) input', function (done) {
+  // disabled due to the 3rd party blockchain provider (3PBP) being down
+  it.skip('can create (and broadcast via 3PBP) a Transaction with a SegWit P2SH(P2WPKH) input', function (done) {
     this.timeout(30000)
 
     var keyPair = bitcoin.ECPair.fromWIF('cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87JcbXMTcA', regtest)
@@ -172,7 +176,8 @@ describe('bitcoinjs-lib (transactions)', function () {
     })
   })
 
-  it('can create (and broadcast via 3PBP) a Transaction with a SegWit 3-of-4 P2SH(P2WSH(multisig)) input', function (done) {
+  // disabled due to the 3rd party blockchain provider (3PBP) being down
+  it.skip('can create (and broadcast via 3PBP) a Transaction with a SegWit 3-of-4 P2SH(P2WSH(multisig)) input', function (done) {
     this.timeout(50000)
 
     var keyPairs = [


### PR DESCRIPTION
There are a few functions in BitGoJS `src/bitcoin.js` which depend on secp256k1 for acceleration of elliptic curve operations. These are low-level functions which really belong in bitgo-utxo-lib.

Signed-off-by: Tyler Levine <tyler@bitgo.com>