### PR TITLE
BG-8910: Fix issue with falsey return values from fastcurve

### DIFF
--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -136,8 +136,7 @@ ECPair.prototype.sign = function (hash) {
   if (!this.d) throw new Error('Missing private key')
 
   var sig = fastcurve.sign(hash, this.d)
-
-  if (sig) return sig
+  if (sig !== undefined) return sig
   return ecdsa.sign(hash, this.d)
 }
 
@@ -149,7 +148,7 @@ ECPair.prototype.toWIF = function () {
 
 ECPair.prototype.verify = function (hash, signature) {
   var fastsig = fastcurve.verify(hash, signature, this.getPublicKeyBuffer())
-  if (fastsig) return fastsig
+  if (fastsig !== undefined) return fastsig
   return ecdsa.verify(hash, signature, this.Q)
 }
 

--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -260,7 +260,7 @@ HDNode.prototype.derive = function (index) {
     // Ki = point(parse256(IL)) + Kpar
     //    = G*IL + Kpar
     var point = fastcurve.publicKeyCreate(IL, false)
-    var Ki = point
+    var Ki = point !== undefined
       ? ecurve.Point.decodeFrom(curve, point).add(this.keyPair.Q)
       : curve.G.multiply(pIL).add(this.keyPair.Q)
 
@@ -348,7 +348,7 @@ HDNode.prototype.cloneKeypair = function () {
   // if Q is not set here, it will be lazily computed via the slow path
   if (!result.__Q) {
     var point = fastcurve.publicKeyCreate(k.d.toBuffer(32), false)
-    if (point) {
+    if (point !== undefined) {
       result.__Q = ecurve.Point.decodeFrom(curve, point)
     }
   }

--- a/test/ecpair.js
+++ b/test/ecpair.js
@@ -288,6 +288,15 @@ describe('ECPair', function () {
 
         keyPair.verify(hash, signature)
       }))
+
+      it('handles falsey return values from fastcurve.verify', sinon.test(function () {
+        this.mock(fastcurve).expects('verify')
+        .once().withArgs(hash, signature, keyPair.getPublicKeyBuffer()).returns(false)
+
+        this.mock(ecdsa).expects('verify').never()
+
+        keyPair.verify(hash, signature)
+      }))
     })
   })
 })


### PR DESCRIPTION
* If fastcurve returns a falsey value (for example, if it determines
that a signature is invalid and returns false from verify), it will be
treated as though the fast path is not available, and will attempt to
re-verify using the slow path.

Signed-off-by: Tyler Levine <tyler@bitgo.com>