### PR TITLE
Bg 9740 add bsv support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitgo-utxo-lib",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "engines": {

--- a/src/coins.js
+++ b/src/coins.js
@@ -3,6 +3,7 @@ const typeforce = require('typeforce')
 
 const coins = {
   BCH: 'bch',
+  BSV: 'bsv',
   BTC: 'btc',
   BTG: 'btg',
   LTC: 'ltc',
@@ -16,6 +17,10 @@ coins.isBitcoin = function (network) {
 
 coins.isBitcoinCash = function (network) {
   return typeforce.value(coins.BCH)(network.coin)
+}
+
+coins.isBitcoinSV = function (network) {
+  return typeforce.value(coins.BSV)(network.coin)
 }
 
 coins.isBitcoinGold = function (network) {
@@ -33,6 +38,7 @@ coins.isZcash = function (network) {
 coins.isValidCoin = typeforce.oneOf(
   coins.isBitcoin,
   coins.isBitcoinCash,
+  coins.isBitcoinSV,
   coins.isBitcoinGold,
   coins.isLitecoin,
   coins.isZcash

--- a/src/networks.js
+++ b/src/networks.js
@@ -50,6 +50,31 @@ module.exports = {
     wif: 0xef,
     coin: coins.BCH
   },
+  bitcoinsv: {
+    messagePrefix: '\x18Bitcoin Signed Message:\n',
+    bech32: 'bc',
+    bip32: {
+      public: 0x0488b21e,
+      private: 0x0488ade4
+    },
+    pubKeyHash: 0x00,
+    scriptHash: 0x05,
+    wif: 0x80,
+    coin: coins.BSV,
+    forkId: 0x00
+  },
+  bitcoincashsv: {
+    messagePrefix: '\x18Bitcoin Signed Message:\n',
+    bech32: 'tb',
+    bip32: {
+      public: 0x043587cf,
+      private: 0x04358394
+    },
+    pubKeyHash: 0x6f,
+    scriptHash: 0xc4,
+    wif: 0xef,
+    coin: coins.BSV
+  },
   zcash: {
     messagePrefix: '\x18ZCash Signed Message:\n',
     bech32: 'bc',

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -197,6 +197,7 @@ function fixMultisigOrder (input, transaction, vin, value, network) {
       var parsed = ECSignature.parseScriptSignature(signature)
       var hash
       switch (network.coin) {
+        case coins.BSV:
         case coins.BCH:
           hash = transaction.hashForCashSignature(vin, input.signScript, value, parsed.hashType)
           break
@@ -797,7 +798,7 @@ TransactionBuilder.prototype.sign = function (vin, keyPair, redeemScript, hashTy
   if (coins.isBitcoinGold(this.network)) {
     signatureHash = this.tx.hashForGoldSignature(vin, input.signScript, witnessValue, hashType, input.witness)
     debug('Calculated BTG sighash (%s)', signatureHash.toString('hex'))
-  } else if (coins.isBitcoinCash(this.network)) {
+  } else if (coins.isBitcoinCash(this.network) || coins.isBitcoinSV(this.network)) {
     signatureHash = this.tx.hashForCashSignature(vin, input.signScript, witnessValue, hashType)
     debug('Calculated BCH sighash (%s)', signatureHash.toString('hex'))
   } else if (coins.isZcash(this.network)) {

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -168,6 +168,10 @@ describe('TransactionBuilder', function () {
         }, new RegExp(errorMessage))
 
         assert.throws(function () {
+          TransactionBuilder.fromTransaction(tx, NETWORKS.bitcoinsv)
+        }, new RegExp(errorMessage))
+
+        assert.throws(function () {
           TransactionBuilder.fromTransaction(tx, NETWORKS.bitcoingold)
         }, new RegExp(errorMessage))
 
@@ -206,7 +210,7 @@ describe('TransactionBuilder', function () {
     })
   })
 
-  var networksToTest = ['bitcoin', 'bitcoingold', 'bitcoincash', 'zcashTest']
+  var networksToTest = ['bitcoin', 'bitcoingold', 'bitcoincash', 'bitcoinsv', 'zcashTest']
   networksToTest.forEach(function (network) {
     describe('addInput for ' + network, function () {
       var testNetwork = NETWORKS[network]


### PR DESCRIPTION
Bitcoin SV is a fork of Bitcoin Cash. The only thing we have to do is to add a new network object and add make sure it uses the same logic as `bitcoincash`.