### PR TITLE
BG-10188 use ripemd160 if rmd160 is not supported

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,7 +1,15 @@
 var createHash = require('create-hash')
+var crypto = require('crypto')
 
 function ripemd160 (buffer) {
-  return createHash('rmd160').update(buffer).digest()
+  var hash = 'rmd160'
+  var supportedHashes = crypto.getHashes()
+  // some environments (electron) only support the long alias
+  if (supportedHashes.indexOf(hash) === -1 && supportedHashes.indexOf('ripemd160') !== -1) {
+    hash = 'ripemd160'
+  }
+
+  return createHash(hash).update(buffer).digest()
 }
 
 function sha1 (buffer) {


### PR DESCRIPTION
Electron switched from openSSL to boringSSL and forgot to implement `ripemd160` and when they did, they ignored the short alias `rmd160`: https://github.com/electron/electron/pull/16572

If the current environment does not support `rmd160` but supports `ripemd160`, we now use that one. If it doesn't support either, it will still die with `Digest method not supported`