### PR TITLE
Bump version to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitgo-utxo-lib",
-  "version": "1.3.1",
+  "version": "1.4.1",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "engines": {


### PR DESCRIPTION
- New feature: LTC network statics
- Version 1.4.1 because tag 1.4.0 got used previously on this repo