### PR TITLE
Bump version to 1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitgo-utxo-lib",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "engines": {


### PR DESCRIPTION
Bumping the version so we can release a new npm version to be used in the platform and keyserver.