### PR TITLE
Update Zcash mainnet network params due to Blossom upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitgo-utxo-lib",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "engines": {

--- a/src/networks.js
+++ b/src/networks.js
@@ -91,7 +91,8 @@ module.exports = {
       1: 0x00,
       2: 0x00,
       3: 0x5ba81b19,
-      4: 0x76b809bb
+      // 4: 0x76b809bb (old Sapling branch id). Blossom branch id becomes effective after block 653600
+      4: 0x2bb40e60
     },
     coin: coins.ZEC
   },


### PR DESCRIPTION
[BLOCK-214](https://bitgoinc.atlassian.net/browse/BLOCK-214) New branch id id `0x2BB40E60`:
https://github.com/zcash/zips/blob/master/zip-0206.rst