### PR TITLE
BLOCK-228 Updated version to "1.7.0-rc.0" for publishing to npmjs and testing internal components.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitgo-utxo-lib",
-  "version": "1.7.0",
+  "version": "1.7.0-rc.0",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "engines": {


### PR DESCRIPTION
JIRA Ticket: [BLOCK-228](https://bitgoinc.atlassian.net/browse/BLOCK-228)
Updated version to "1.7.0-rc.0" for publishing to npmjs and testing internal components without affecting external community.

When prime time, Tue 12/10/19 - Wed 12/11/19, we'll then update to the official "1.7.0" release version.