### PR TITLE
Add src/bitgo/keyutil

### DIFF
--- a/src/bitgo/index.js
+++ b/src/bitgo/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  keyutil: require('./keyutil')
+}

--- a/src/bitgo/keyutil.js
+++ b/src/bitgo/keyutil.js
@@ -1,4 +1,3 @@
-const ecurve = require('ecurve')
 const BigInteger = require('bigi')
 const ECPair = require('../ecpair')
 

--- a/src/bitgo/keyutil.js
+++ b/src/bitgo/keyutil.js
@@ -1,0 +1,38 @@
+const ecurve = require('ecurve')
+const BigInteger = require('bigi')
+const ECPair = require('../ecpair')
+
+/**
+ * Create an ECPair from the raw private key bytes
+ * @param {Buffer} buffer - Private key for the ECPair. Must be exactly 32 bytes.
+ * @param {Object} [network] - Network for the ECPair. Defaults to bitcoin.
+ * @return {ECPair}
+ */
+function privateKeyBufferToECPair (buffer, network) {
+  if (!Buffer.isBuffer(buffer) || buffer.length !== 32) {
+    throw new Error('invalid private key buffer')
+  }
+
+  const d = BigInteger.fromBuffer(buffer)
+  return new ECPair(d, null, { network })
+}
+
+/**
+ * Get the private key as a 32 bytes buffer. If it is smaller than 32 bytes, pad it with zeros
+ * @param {ECPair} ecPair
+ * @return {Buffer} 32 bytes
+ */
+function privateKeyBufferFromECPair (ecPair) {
+  if (!(ecPair instanceof ECPair)) {
+    throw new TypeError(`invalid argument ecpair`)
+  }
+
+  if (!ecPair.d) throw new Error('Missing private key')
+
+  return ecPair.d.toBuffer(32)
+}
+
+module.exports = {
+  privateKeyBufferToECPair,
+  privateKeyBufferFromECPair
+}

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -138,15 +138,7 @@ ECPair.prototype.getPublicKeyBuffer = function () {
 ECPair.prototype.getPrivateKeyBuffer = function () {
   if (!this.d) throw new Error('Missing private key')
 
-  var bigIntBuffer = this.d.toBuffer()
-  if (bigIntBuffer.length > 32) throw new Error('Private key size exceeds 32 bytes')
-
-  if (bigIntBuffer.length === 32) {
-    return bigIntBuffer
-  }
-  var newBuffer = Buffer.alloc(32)
-  bigIntBuffer.copy(newBuffer, newBuffer.length - bigIntBuffer.length, 0, bigIntBuffer.length)
-  return newBuffer
+  return this.d.toBuffer(32)
 }
 
 ECPair.prototype.sign = function (hash) {

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -60,22 +60,6 @@ ECPair.fromPublicKeyBuffer = function (buffer, network) {
     network: network
   })
 }
-
-/**
- * Create an ECPair from the raw private key bytes
- * @param buffer {Buffer} Private key for the ECPair. Must be exactly 32 bytes.
- * @param network {Object} Network for the ECPair. Defaults to bitcoin.
- * @return {ECPair}
- */
-ECPair.fromPrivateKeyBuffer = function (buffer, network) {
-  if (!Buffer.isBuffer(buffer) || buffer.length !== 32) {
-    throw new Error('invalid private key buffer')
-  }
-
-  var d = BigInteger.fromBuffer(buffer)
-  return new ECPair(d, null, { network: network })
-}
-
 ECPair.fromWIF = function (string, network) {
   var decoded = wif.decode(string)
   var version = decoded.version
@@ -131,16 +115,6 @@ ECPair.prototype.getPublicKeyBuffer = function () {
   return this.Q.getEncoded(this.compressed)
 }
 
-/**
- * Get the private key as a 32 bytes buffer. If it is smaller than 32 bytes, pad it with zeros
- * @return Buffer
- */
-ECPair.prototype.getPrivateKeyBuffer = function () {
-  if (!this.d) throw new Error('Missing private key')
-
-  return this.d.toBuffer(32)
-}
-
 ECPair.prototype.sign = function (hash) {
   if (!this.d) throw new Error('Missing private key')
 
@@ -159,6 +133,28 @@ ECPair.prototype.verify = function (hash, signature) {
   var fastsig = fastcurve.verify(hash, signature, this.getPublicKeyBuffer())
   if (fastsig !== undefined) return fastsig
   return ecdsa.verify(hash, signature, this.Q)
+}
+
+/**
+ * @deprecated
+ * Use {@see keyutil.privateKeyBufferToECPair} instead
+ * Will be removed in next major version (BLOCK-267)
+ */
+ECPair.fromPrivateKeyBuffer = function (buffer, network) {
+  // toplevel import unavailable due to circular dependency
+  var keyutil = require('./bitgo/keyutil')
+  return keyutil.privateKeyBufferToECPair(buffer, network)
+}
+
+/**
+ * @deprecated
+ * Use {@see keyutil.privateKeyBufferFromECPair} instead
+ * Will be removed in next major version (BLOCK-267)
+ */
+ECPair.prototype.getPrivateKeyBuffer = function () {
+  // toplevel import unavailable due to circular dependency
+  var keyutil = require('./bitgo/keyutil')
+  return keyutil.privateKeyBufferFromECPair(this)
 }
 
 module.exports = ECPair

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -44,7 +44,8 @@ function ECPair (d, Q, options) {
 Object.defineProperty(ECPair.prototype, 'Q', {
   get: function () {
     if (!this.__Q && this.d) {
-      this.__Q = secp256k1.G.multiply(this.d)
+      const qBuf = fastcurve.publicKeyCreate(this.d.toBuffer(32), false)
+      this.__Q = qBuf ? ecurve.Point.decodeFrom(curve, qBuf) : secp256k1.G.multiply(this.d)
     }
 
     return this.__Q
@@ -72,17 +73,7 @@ ECPair.fromPrivateKeyBuffer = function (buffer, network) {
   }
 
   var d = BigInteger.fromBuffer(buffer)
-
-  if (d.signum() <= 0 || d.compareTo(curve.n) >= 0) {
-    throw new Error('private key out of range')
-  }
-
-  var ecPair = new ECPair(d, null, { network: network })
-  if (!ecPair.__Q && curve) {
-    ecPair.__Q = ecurve.Point.decodeFrom(curve, fastcurve.publicKeyCreate(d.toBuffer(32), false))
-  }
-
-  return ecPair
+  return new ECPair(d, null, { network: network })
 }
 
 ECPair.fromWIF = function (string, network) {

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ for (var key in templates) {
 }
 
 module.exports = {
+  bitgo: require('./bitgo'),
   bufferutils: require('./bufferutils'), // TODO: remove in 4.0.0
 
   Block: require('./block'),

--- a/test/bitgo/keyutil.js
+++ b/test/bitgo/keyutil.js
@@ -29,6 +29,12 @@ describe('privateKeyBufferFromECPair', function () {
     assert.strictEqual(privateKeyBufferFromECPair(keyPair).length, 32)
     assert.strictEqual(privateKeyBufferFromECPair(keyPair).toString('hex'), hexString)
   })
+
+  it('throws if passed value is not ecpair', function () {
+    assert.throws(function () {
+      privateKeyBufferFromECPair({})
+    }, new RegExp('invalid argument ecpair'))
+  })
 })
 
 describe('privateKeyBufferToECPair', function () {

--- a/test/bitgo/keyutil.js
+++ b/test/bitgo/keyutil.js
@@ -18,7 +18,7 @@ const {
 describe('privateKeyBufferFromECPair', function () {
   it('pads short private keys', function () {
     var keyPair = new ECPair(BigInteger.ONE)
-    assert.strictEqual(privateKeyBufferFromECPair(keyPair).byteLength, 32)
+    assert.strictEqual(privateKeyBufferFromECPair(keyPair).length, 32)
     assert.strictEqual(privateKeyBufferFromECPair(keyPair).toString('hex'),
       '0000000000000000000000000000000000000000000000000000000000000001')
   })
@@ -26,7 +26,7 @@ describe('privateKeyBufferFromECPair', function () {
   it('does not pad 32 bytes private keys', function () {
     var hexString = 'a000000000000000000000000000000000000000000000000000000000000000'
     var keyPair = new ECPair(new BigInteger(hexString, 16))
-    assert.strictEqual(privateKeyBufferFromECPair(keyPair).byteLength, 32)
+    assert.strictEqual(privateKeyBufferFromECPair(keyPair).length, 32)
     assert.strictEqual(privateKeyBufferFromECPair(keyPair).toString('hex'), hexString)
   })
 

--- a/test/bitgo/keyutil.js
+++ b/test/bitgo/keyutil.js
@@ -1,0 +1,73 @@
+/* global describe, it */
+
+const assert = require('assert')
+var randombytes = require('randombytes')
+
+const BigInteger = require('bigi')
+
+const {
+  bitgo: {
+    keyutil: {
+      privateKeyBufferToECPair,
+      privateKeyBufferFromECPair
+    }
+  },
+  ECPair
+} = require('../../src')
+
+describe('privateKeyBufferFromECPair', function () {
+  it('pads short private keys', function () {
+    var keyPair = new ECPair(BigInteger.ONE)
+    assert.strictEqual(privateKeyBufferFromECPair(keyPair).byteLength, 32)
+    assert.strictEqual(privateKeyBufferFromECPair(keyPair).toString('hex'),
+      '0000000000000000000000000000000000000000000000000000000000000001')
+  })
+
+  it('does not pad 32 bytes private keys', function () {
+    var hexString = 'a000000000000000000000000000000000000000000000000000000000000000'
+    var keyPair = new ECPair(new BigInteger(hexString, 16))
+    assert.strictEqual(privateKeyBufferFromECPair(keyPair).byteLength, 32)
+    assert.strictEqual(privateKeyBufferFromECPair(keyPair).toString('hex'), hexString)
+  })
+
+  it('throws if the key is too long', function () {
+    var hexString = '10000000000000000000000000000000000000000000000000000000000000000'
+
+    assert.throws(function () {
+      var keyPair = new ECPair(new BigInteger(hexString, 16))
+      privateKeyBufferFromECPair(keyPair)
+    }, new RegExp('Private key must be less than the curve order'))
+  })
+})
+
+describe('privateKeyBufferToECPair', function () {
+  it('constructs an ECPair from a random private key buffer', function () {
+    var prvKeyBuffer = randombytes(32)
+    var ecPair = privateKeyBufferToECPair(prvKeyBuffer)
+    var ecPairPrvBuffer = privateKeyBufferFromECPair(ecPair)
+    assert.strictEqual(Buffer.compare(ecPairPrvBuffer, prvKeyBuffer), 0)
+  })
+
+  it('throws if the private key is out of range', function () {
+    var prvKeyBuffer = Buffer.alloc(32, 0xff)
+    assert.throws(function () {
+      privateKeyBufferToECPair(prvKeyBuffer)
+    }, new RegExp('private key out of range'))
+  })
+
+  it('throws if the private key buffer is not a buffer', function () {
+    assert.throws(function () {
+      privateKeyBufferToECPair('not a buffer')
+    }, new RegExp('invalid private key buffer'))
+  })
+
+  it('throws if the private key buffer is not 32 bytes', function () {
+    assert.throws(function () {
+      privateKeyBufferToECPair(Buffer.alloc(31, 0x00))
+    }, new RegExp('invalid private key buffer'))
+
+    assert.throws(function () {
+      privateKeyBufferToECPair(Buffer.alloc(33, 0x00))
+    }, new RegExp('invalid private key buffer'))
+  })
+})

--- a/test/bitgo/keyutil.js
+++ b/test/bitgo/keyutil.js
@@ -1,7 +1,7 @@
 /* global describe, it */
 
 const assert = require('assert')
-var randombytes = require('randombytes')
+const crypto = require('crypto')
 
 const BigInteger = require('bigi')
 
@@ -42,7 +42,7 @@ describe('privateKeyBufferFromECPair', function () {
 
 describe('privateKeyBufferToECPair', function () {
   it('constructs an ECPair from a random private key buffer', function () {
-    var prvKeyBuffer = randombytes(32)
+    var prvKeyBuffer = crypto.randomBytes(32)
     var ecPair = privateKeyBufferToECPair(prvKeyBuffer)
     var ecPairPrvBuffer = privateKeyBufferFromECPair(ecPair)
     assert.strictEqual(Buffer.compare(ecPairPrvBuffer, prvKeyBuffer), 0)

--- a/test/bitgo/keyutil.js
+++ b/test/bitgo/keyutil.js
@@ -29,15 +29,6 @@ describe('privateKeyBufferFromECPair', function () {
     assert.strictEqual(privateKeyBufferFromECPair(keyPair).length, 32)
     assert.strictEqual(privateKeyBufferFromECPair(keyPair).toString('hex'), hexString)
   })
-
-  it('throws if the key is too long', function () {
-    var hexString = '10000000000000000000000000000000000000000000000000000000000000000'
-
-    assert.throws(function () {
-      var keyPair = new ECPair(new BigInteger(hexString, 16))
-      privateKeyBufferFromECPair(keyPair)
-    }, new RegExp('Private key must be less than the curve order'))
-  })
 })
 
 describe('privateKeyBufferToECPair', function () {
@@ -46,13 +37,6 @@ describe('privateKeyBufferToECPair', function () {
     var ecPair = privateKeyBufferToECPair(prvKeyBuffer)
     var ecPairPrvBuffer = privateKeyBufferFromECPair(ecPair)
     assert.strictEqual(Buffer.compare(ecPairPrvBuffer, prvKeyBuffer), 0)
-  })
-
-  it('throws if the private key is out of range', function () {
-    var prvKeyBuffer = Buffer.alloc(32, 0xff)
-    assert.throws(function () {
-      privateKeyBufferToECPair(prvKeyBuffer)
-    }, new RegExp('private key out of range'))
   })
 
   it('throws if the private key buffer is not a buffer', function () {

--- a/test/ecpair.js
+++ b/test/ecpair.js
@@ -313,7 +313,7 @@ describe('ECPair', function () {
       var prvKeyBuffer = Buffer.alloc(32, 0xff)
       assert.throws(function () {
         ECPair.fromPrivateKeyBuffer(prvKeyBuffer)
-      }, new RegExp('private key out of range'))
+      }, new RegExp('Private key must be less than the curve order'))
     })
 
     it('throws if the private key buffer is not a buffer', function () {

--- a/test/ecpair.js
+++ b/test/ecpair.js
@@ -84,6 +84,11 @@ describe('ECPair', function () {
     }))
   })
 
+  /**
+   * @deprecated
+   * Use {@see keyutil.privateKeyBufferToECPair} instead
+   * Will be removed in next major version (BLOCK-267)
+   */
   describe('getPrivateKeyBuffer', function () {
     it('pads short private keys', sinon.test(function () {
       var keyPair = new ECPair(BigInteger.ONE)
@@ -301,6 +306,11 @@ describe('ECPair', function () {
     })
   })
 
+  /**
+   * @deprecated
+   * Use {@see keyutil.privateKeyBufferToECPair} instead
+   * Will be removed in next major version (BLOCK-267)
+   */
   describe('fromPrivateKeyBuffer', function () {
     it('constructs an ECPair from a random private key buffer', function () {
       var prvKeyBuffer = randombytes(32)


### PR DESCRIPTION
Move custom key conversion methods to subdir.

This makes the `ECPair` class more compatible with upstream and
reduces conflicts when merging upstream changes.

Issue: BLOCK-261