### PR TITLE
Skip failing integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,20 @@ node_js:
   - "8"
   - "9"
   - "10"
+
+env:
+  global:
+    - BITGO_UTXO_LIB_TEST_SKIP_3PBP=1 # BLOCK-253
+  jobs:
+    - TEST_SUITE=standard
+    - TEST_SUITE=coverage
+
 matrix:
   include:
     - node_js: "7"
       env: TEST_SUITE=standard
     - node_js: "7"
       env: TEST_SUITE=coverage
-env:
-  - TEST_SUITE=integration
-  - TEST_SUITE=unit
-script: npm run-script $TEST_SUITE
+
+script:
+  - npm run-script $TEST_SUITE

--- a/test/forks/btg/transaction_builder.js
+++ b/test/forks/btg/transaction_builder.js
@@ -8,7 +8,7 @@ const {
   networks,
   ECPair,
   script,
-  crypto,
+  crypto
 } = require('..')
 
 describe('TransactionBuilder (BTG)', function () {

--- a/test/integration/addresses.js
+++ b/test/integration/addresses.js
@@ -98,6 +98,12 @@ describe('bitcoinjs-lib (addresses)', function () {
   })
 
   it('can support the retrieval of transactions for an address (via 3PBP)', function (done) {
+    if (process.env.BITGO_UTXO_LIB_TEST_SKIP_3PBP === '1') {
+      console.warn(`BLOCK-253 - skip test because we can get rate limited by Cloudflare`)
+      this.skip()
+      return done()
+    }
+
     var keyPair = bitcoin.ECPair.makeRandom()
     var address = keyPair.getAddress()
 


### PR DESCRIPTION
One of the tests calls out to `blockchain.info` to an extent that we get
rate limited by Cloudflare.

The decrease in test coverage is justified by having a meaningful CI result
again.

Issue: BLOCK-253

Other Changes:

1a910f9
Make code pass `standard` linter

Due to alert fatigue this was missed earlier