### PR TITLE
Actually run tests in test/forks/

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "coverage-report": "nyc report --reporter=lcov",
     "coverage-html": "nyc report --reporter=html",
-    "coverage": "nyc --check-coverage --branches 90 --functions 90 mocha",
+    "coverage": "nyc --check-coverage --branches 90 --functions 90 mocha test/ test/forks/*",
     "integration": "mocha test/integration/",
     "standard": "standard",
     "test": "npm run standard && npm run coverage",

--- a/test/forks/btg/transaction_builder.js
+++ b/test/forks/btg/transaction_builder.js
@@ -9,7 +9,7 @@ const {
   ECPair,
   script,
   crypto
-} = require('..')
+} = require('../../../src')
 
 describe('TransactionBuilder (BTG)', function () {
   var network = networks['bitcoingold']


### PR DESCRIPTION
Since `coverage` only runs mocha, which does not run tests recursively
by default, the coverage dropped below 90%. This change barely moves
it above 90% again.

Issue: BLOCK-251