### PR TITLE
Bump version to 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitgo-utxo-lib",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "engines": {


### PR DESCRIPTION
* Add deprecation notice for `ECPair.fromPrivateKeyBuffer`:
  use `utxolib.bitgo.keyutil.privateKeyBufferToECPair` instead

* Add deprecation notice for `ECPair.getPrivateKeyBuffer`:
  use `utxolib.bitgo.keyutil.privateKeyBufferToECPair` instead

Issue: BG-16464