### PR TITLE
Improve src/networks.js

### DIFF
--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -68,7 +68,7 @@ ECPair.fromWIF = function (string, network) {
   if (types.Array(network)) {
     network = network.filter(function (x) {
       return version === x.wif
-    }).pop()  // We should not use pop since it depends on the order of the networks for the same wif
+    }).pop()
 
     if (!network) throw new Error('Unknown network version')
 

--- a/src/networks.js
+++ b/src/networks.js
@@ -17,29 +17,32 @@ wif:           src/chainparams.cpp  base58Prefixes[SECRET_KEY]
 var coins = require('./coins')
 
 module.exports = {
-  // https://github.com/dashpay/dash/blob/master/src/validation.cpp
-  // https://github.com/dashpay/dash/blob/master/src/chainparams.cpp
-  dash: {
-    messagePrefix: '\x19DarkCoin Signed Message:\n',
+
+  // https://github.com/bitcoin/bitcoin/blob/master/src/validation.cpp
+  // https://github.com/bitcoin/bitcoin/blob/master/src/chainparams.cpp
+  bitcoin: {
+    messagePrefix: '\x18Bitcoin Signed Message:\n',
+    bech32: 'bc',
     bip32: {
       public: 0x0488b21e,
       private: 0x0488ade4
     },
-    pubKeyHash: 0x4c,
-    scriptHash: 0x10,
-    wif: 0xcc,
-    coin: coins.DASH
+    pubKeyHash: 0x00,
+    scriptHash: 0x05,
+    wif: 0x80,
+    coin: coins.BTC
   },
-  dashTest: {
-    messagePrefix: '\x19DarkCoin Signed Message:\n',
+  testnet: {
+    messagePrefix: '\x18Bitcoin Signed Message:\n',
+    bech32: 'tb',
     bip32: {
       public: 0x043587cf,
       private: 0x04358394
     },
-    pubKeyHash: 0x8c,
-    scriptHash: 0x13,
+    pubKeyHash: 0x6f,
+    scriptHash: 0xc4,
     wif: 0xef,
-    coin: coins.DASH
+    coin: coins.BTC
   },
 
   // https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/src/validation.cpp
@@ -68,6 +71,23 @@ module.exports = {
     coin: coins.BCH
   },
 
+  // https://github.com/BTCGPU/BTCGPU/blob/master/src/validation.cpp
+  // https://github.com/BTCGPU/BTCGPU/blob/master/src/chainparams.cpp
+  bitcoingold: {
+    messagePrefix: '\x18Bitcoin Gold Signed Message:\n',
+    bech32: 'btg',
+    bip32: {
+      public: 0x0488b21e,
+      private: 0x0488ade4
+    },
+    pubKeyHash: 0x26,
+    scriptHash: 0x17,
+    wif: 0x80,
+    coin: coins.BTG,
+    forkId: 0x4F /* 79 */
+  },
+  // bitcoingoldTest: TODO
+
   // https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/validation.cpp
   // https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/chainparams.cpp
   bitcoinsv: {
@@ -92,6 +112,58 @@ module.exports = {
     scriptHash: 0xc4,
     wif: 0xef,
     coin: coins.BSV
+  },
+
+  // https://github.com/dashpay/dash/blob/master/src/validation.cpp
+  // https://github.com/dashpay/dash/blob/master/src/chainparams.cpp
+  dash: {
+    messagePrefix: '\x19DarkCoin Signed Message:\n',
+    bip32: {
+      public: 0x0488b21e,
+      private: 0x0488ade4
+    },
+    pubKeyHash: 0x4c,
+    scriptHash: 0x10,
+    wif: 0xcc,
+    coin: coins.DASH
+  },
+  dashTest: {
+    messagePrefix: '\x19DarkCoin Signed Message:\n',
+    bip32: {
+      public: 0x043587cf,
+      private: 0x04358394
+    },
+    pubKeyHash: 0x8c,
+    scriptHash: 0x13,
+    wif: 0xef,
+    coin: coins.DASH
+  },
+
+  // https://github.com/litecoin-project/litecoin/blob/master/src/validation.cpp
+  // https://github.com/litecoin-project/litecoin/blob/master/src/chainparams.cpp
+  litecoin: {
+    messagePrefix: '\x19Litecoin Signed Message:\n',
+    bech32: 'ltc',
+    bip32: {
+      public: 0x019da462,
+      private: 0x019d9cfe
+    },
+    pubKeyHash: 0x30,
+    scriptHash: 0x32,
+    wif: 0xb0,
+    coin: coins.LTC
+  },
+  litecoinTest: {
+    messagePrefix: '\x19Litecoin Signed Message:\n',
+    bech32: 'tltc',
+    bip32: {
+      public: 0x0488b21e,
+      private: 0x0488ade4
+    },
+    pubKeyHash: 0x6f,
+    scriptHash: 0x3a,
+    wif: 0xb0,
+    coin: coins.LTC
   },
 
   // https://github.com/zcash/zcash/blob/master/src/validation.cpp
@@ -133,76 +205,5 @@ module.exports = {
       4: 0x2bb40e60
     },
     coin: coins.ZEC
-  },
-
-  // https://github.com/BTCGPU/BTCGPU/blob/master/src/validation.cpp
-  // https://github.com/BTCGPU/BTCGPU/blob/master/src/chainparams.cpp
-  bitcoingold: {
-    messagePrefix: '\x18Bitcoin Gold Signed Message:\n',
-    bech32: 'btg',
-    bip32: {
-      public: 0x0488b21e,
-      private: 0x0488ade4
-    },
-    pubKeyHash: 0x26,
-    scriptHash: 0x17,
-    wif: 0x80,
-    coin: coins.BTG,
-    forkId: 0x4F /* 79 */
-  },
-  // bitcoingoldTest: TODO
-
-  // https://github.com/litecoin-project/litecoin/blob/master/src/validation.cpp
-  // https://github.com/litecoin-project/litecoin/blob/master/src/chainparams.cpp
-  litecoin: {
-    messagePrefix: '\x19Litecoin Signed Message:\n',
-    bech32: 'ltc',
-    bip32: {
-      public: 0x019da462,
-      private: 0x019d9cfe
-    },
-    pubKeyHash: 0x30,
-    scriptHash: 0x32,
-    wif: 0xb0,
-    coin: coins.LTC
-  },
-  litecoinTest: {
-    messagePrefix: '\x19Litecoin Signed Message:\n',
-    bech32: 'tltc',
-    bip32: {
-      public: 0x0488b21e,
-      private: 0x0488ade4
-    },
-    pubKeyHash: 0x6f,
-    scriptHash: 0x3a,
-    wif: 0xb0,
-    coin: coins.LTC
-  },
-
-  // https://github.com/bitcoin/bitcoin/blob/master/src/validation.cpp
-  // https://github.com/bitcoin/bitcoin/blob/master/src/chainparams.cpp
-  bitcoin: {
-    messagePrefix: '\x18Bitcoin Signed Message:\n',
-    bech32: 'bc',
-    bip32: {
-      public: 0x0488b21e,
-      private: 0x0488ade4
-    },
-    pubKeyHash: 0x00,
-    scriptHash: 0x05,
-    wif: 0x80,
-    coin: coins.BTC
-  },
-  testnet: {
-    messagePrefix: '\x18Bitcoin Signed Message:\n',
-    bech32: 'tb',
-    bip32: {
-      public: 0x043587cf,
-      private: 0x04358394
-    },
-    pubKeyHash: 0x6f,
-    scriptHash: 0xc4,
-    wif: 0xef,
-    coin: coins.BTC
   }
 }

--- a/src/networks.js
+++ b/src/networks.js
@@ -1,15 +1,31 @@
-// https://en.bitcoin.it/wiki/List_of_address_prefixes
-// Dogecoin BIP32 is a proposed standard: https://bitcointalk.org/index.php?topic=409731
+/*
+
+The values for the various fork coins can be found in these files:
+
+property       filename             varname
+------------------------------------------------------------------
+messagePrefix: src/validation.cpp   strMessageMagic
+bech32_hrp:    src/chainparams.cpp  bech32_hrp
+bip32.public:  src/chainparams.cpp  base58Prefixes[EXT_PUBLIC_KEY]
+bip32.private  src/chainparams.cpp  base58Prefixes[EXT_SECRET_KEY]
+pubKeyHash:    src/chainparams.cpp  base58Prefixes[PUBKEY_ADDRESS]
+scriptHash:    src/chainparams.cpp  base58Prefixes[SCRIPT_ADDRESS]
+wif:           src/chainparams.cpp  base58Prefixes[SECRET_KEY]
+
+*/
+
 var coins = require('./coins')
 
 module.exports = {
+  // https://github.com/dashpay/dash/blob/master/src/validation.cpp
+  // https://github.com/dashpay/dash/blob/master/src/chainparams.cpp
   dash: {
     messagePrefix: '\x19DarkCoin Signed Message:\n',
     bip32: {
       public: 0x0488b21e,
       private: 0x0488ade4
     },
-    pubKeyHash: 0x4c, // https://dash-docs.github.io/en/developer-reference#opcodes
+    pubKeyHash: 0x4c,
     scriptHash: 0x10,
     wif: 0xcc,
     coin: coins.DASH
@@ -20,11 +36,14 @@ module.exports = {
       public: 0x043587cf,
       private: 0x04358394
     },
-    pubKeyHash: 0x8c, // https://dash-docs.github.io/en/developer-reference#opcodes
+    pubKeyHash: 0x8c,
     scriptHash: 0x13,
-    wif: 0xef, // https://github.com/dashpay/godashutil/blob/master/wif.go#L72
+    wif: 0xef,
     coin: coins.DASH
   },
+
+  // https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/src/validation.cpp
+  // https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/src/chainparams.cpp
   bitcoincash: {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     bip32: {
@@ -48,6 +67,9 @@ module.exports = {
     wif: 0xef,
     coin: coins.BCH
   },
+
+  // https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/validation.cpp
+  // https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/chainparams.cpp
   bitcoinsv: {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     bip32: {
@@ -71,6 +93,9 @@ module.exports = {
     wif: 0xef,
     coin: coins.BSV
   },
+
+  // https://github.com/zcash/zcash/blob/master/src/validation.cpp
+  // https://github.com/zcash/zcash/blob/master/src/chainparams.cpp
   zcash: {
     messagePrefix: '\x18ZCash Signed Message:\n',
     bip32: {
@@ -109,6 +134,9 @@ module.exports = {
     },
     coin: coins.ZEC
   },
+
+  // https://github.com/BTCGPU/BTCGPU/blob/master/src/validation.cpp
+  // https://github.com/BTCGPU/BTCGPU/blob/master/src/chainparams.cpp
   bitcoingold: {
     messagePrefix: '\x18Bitcoin Gold Signed Message:\n',
     bech32: 'btg',
@@ -122,6 +150,10 @@ module.exports = {
     coin: coins.BTG,
     forkId: 0x4F /* 79 */
   },
+  // bitcoingoldTest: TODO
+
+  // https://github.com/litecoin-project/litecoin/blob/master/src/validation.cpp
+  // https://github.com/litecoin-project/litecoin/blob/master/src/chainparams.cpp
   litecoin: {
     messagePrefix: '\x19Litecoin Signed Message:\n',
     bech32: 'ltc',
@@ -146,6 +178,9 @@ module.exports = {
     wif: 0xb0,
     coin: coins.LTC
   },
+
+  // https://github.com/bitcoin/bitcoin/blob/master/src/validation.cpp
+  // https://github.com/bitcoin/bitcoin/blob/master/src/chainparams.cpp
   bitcoin: {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     bech32: 'bc',

--- a/test/ecpair.js
+++ b/test/ecpair.js
@@ -18,7 +18,15 @@ var curve = ecdsa.__curve
 var NETWORKS = require('../src/networks')
 var NETWORKS_LIST = [] // Object.values(NETWORKS)
 for (var networkName in NETWORKS) {
-  NETWORKS_LIST.push(NETWORKS[networkName])
+  // Methods like `fromWIF` accept a list of networks and select the *last* matching network,
+  // which is expected to be bitcoin/testnet in tests.
+  // Unfortunately some other networks have the same constants, so we make sure that bitcoin
+  // comes last in the array.
+  if (networkName === 'bitcoin' || networkName === 'testnet') {
+    NETWORKS_LIST.push(NETWORKS[networkName])
+  } else {
+    NETWORKS_LIST.unshift(NETWORKS[networkName])
+  }
 }
 
 describe('ECPair', function () {


### PR DESCRIPTION
fe30012
src/networks.js: reorder networks

Order networks alphabetically.

The test `ecpair.js` is modified so that the `NETWORKS_LIST` still has
`bitcoin` and `testnet` as the final elements.

Remove misleading comments.

Issue: BG-16465

0ec6b0b
src/networks.js: fix references

* Remove confusing / invalid references
* Add links to `validation.cpp`/`chainparams.cpp` for various forks

Issue: BG-16465