### PR TITLE
Add tests for networks, describe bugs

### DIFF
--- a/src/coins.js
+++ b/src/coins.js
@@ -55,7 +55,11 @@ function isZcash (network) {
   return typeforce.value(networks.zcash.coin)(network.coin)
 }
 
-isValidCoin = typeforce.oneOf(
+/**
+ * @param network
+ * @returns {boolean} returns true iff network is any of the network stated in the argument
+ */
+const isValidNetwork = typeforce.oneOf(
   isBitcoin,
   isBitcoinCash,
   isBitcoinSV,
@@ -85,5 +89,10 @@ module.exports = {
   isDash,
   isLitecoin,
   isZcash,
-  isValidCoin
+
+  isValidNetwork,
+  /**
+   * @deprecated: use isValidNetwork
+   */
+  isValidCoin: isValidNetwork
 }

--- a/src/coins.js
+++ b/src/coins.js
@@ -1,51 +1,89 @@
 // Coins supported by bitgo-bitcoinjs-lib
 const typeforce = require('typeforce')
 
-const coins = {
-  BCH: 'bch',
-  BSV: 'bsv',
-  BTC: 'btc',
-  BTG: 'btg',
-  LTC: 'ltc',
-  ZEC: 'zec',
-  DASH: 'dash'
+const networks = require('./networks')
+
+function isBitcoin (network) {
+  return typeforce.value(networks.bitcoin.coin)(network.coin)
 }
 
-coins.isBitcoin = function (network) {
-  return typeforce.value(coins.BTC)(network.coin)
+/**
+ * @param network
+ * @returns {boolean} true iff network is bitcoincash or bitcoincashTestnet
+ */
+function isBitcoinCash (network) {
+  return typeforce.value(networks.bitcoincash.coin)(network.coin)
 }
 
-coins.isBitcoinCash = function (network) {
-  return typeforce.value(coins.BCH)(network.coin)
+/**
+ * @param network
+ * @returns {boolean} true iff network is bitcoingold
+ */
+function isBitcoinGold (network) {
+  return typeforce.value(networks.bitcoingold.coin)(network.coin)
 }
 
-coins.isBitcoinSV = function (network) {
-  return typeforce.value(coins.BSV)(network.coin)
+/**
+ * @param network
+ * @returns {boolean} true iff network is bitcoinsv or bitcoinsvTestnet
+ */
+function isBitcoinSV (network) {
+  return typeforce.value(networks.bitcoinsv.coin)(network.coin)
 }
 
-coins.isBitcoinGold = function (network) {
-  return typeforce.value(coins.BTG)(network.coin)
+/**
+ * @param network
+ * @returns {boolean} true iff network is dash or dashTest
+ */
+function isDash (network) {
+  return typeforce.value(networks.dash.coin)(network.coin)
 }
 
-coins.isDash = function (network) {
-  return typeforce.value(coins.DASH)(network.coin)
+/**
+ * @param network
+ * @returns {boolean} true iff network is litecoin or litecoinTest
+ */
+function isLitecoin (network) {
+  return typeforce.value(networks.litecoin.coin)(network.coin)
 }
 
-coins.isLitecoin = function (network) {
-  return typeforce.value(coins.LTC)(network.coin)
+/**
+ * @param network
+ * @returns {boolean} true iff network is zcash or zcashTest
+ */
+function isZcash (network) {
+  return typeforce.value(networks.zcash.coin)(network.coin)
 }
 
-coins.isZcash = function (network) {
-  return typeforce.value(coins.ZEC)(network.coin)
-}
-
-coins.isValidCoin = typeforce.oneOf(
-  coins.isBitcoin,
-  coins.isBitcoinCash,
-  coins.isBitcoinSV,
-  coins.isBitcoinGold,
-  coins.isLitecoin,
-  coins.isZcash
+isValidCoin = typeforce.oneOf(
+  isBitcoin,
+  isBitcoinCash,
+  isBitcoinSV,
+  isBitcoinGold,
+  isLitecoin,
+  isZcash
 )
 
-module.exports = coins
+module.exports = {
+  BTC: networks.bitcoin.coin,
+  BCH: networks.bitcoincash.coin,
+  BSV: networks.bitcoinsv.coin,
+  BTG: networks.bitcoingold.coin,
+  DASH: networks.dash.coin,
+  LTC: networks.litecoin.coin,
+  ZEC: networks.zcash.coin,
+
+  getMainnet,
+  isMainnet,
+  getTestnet,
+  isTestnet,
+
+  isBitcoin,
+  isBitcoinCash,
+  isBitcoinGold,
+  isBitcoinSV,
+  isDash,
+  isLitecoin,
+  isZcash,
+  isValidCoin
+}

--- a/src/coins.js
+++ b/src/coins.js
@@ -62,8 +62,9 @@ function isZcash (network) {
 const isValidNetwork = typeforce.oneOf(
   isBitcoin,
   isBitcoinCash,
-  isBitcoinSV,
   isBitcoinGold,
+  isBitcoinSV,
+  isDash,
   isLitecoin,
   isZcash
 )

--- a/src/networks.js
+++ b/src/networks.js
@@ -153,6 +153,7 @@ module.exports = {
     messagePrefix: '\x19Litecoin Signed Message:\n',
     bech32: 'ltc',
     bip32: {
+      // FIXME(BG-16466): these are incorrect
       public: 0x019da462,
       private: 0x019d9cfe
     },
@@ -165,6 +166,7 @@ module.exports = {
     messagePrefix: '\x19Litecoin Signed Message:\n',
     bech32: 'tltc',
     bip32: {
+      // FIXME(BG-16466): these are incorrect
       public: 0x0488b21e,
       private: 0x0488ade4
     },

--- a/src/networks.js
+++ b/src/networks.js
@@ -14,7 +14,16 @@ wif:           src/chainparams.cpp  base58Prefixes[SECRET_KEY]
 
 */
 
-var coins = require('./coins')
+const coins = {
+  BCH: 'bch',
+  BSV: 'bsv',
+  BTC: 'btc',
+  BTG: 'btg',
+  LTC: 'ltc',
+  ZEC: 'zec',
+  DASH: 'dash'
+}
+
 
 module.exports = {
 

--- a/src/networks.js
+++ b/src/networks.js
@@ -24,7 +24,6 @@ const coins = {
   DASH: 'dash'
 }
 
-
 module.exports = {
 
   // https://github.com/bitcoin/bitcoin/blob/master/src/validation.cpp
@@ -171,6 +170,7 @@ module.exports = {
     },
     pubKeyHash: 0x6f,
     scriptHash: 0x3a,
+    // FIXME(BG-16466): should be 0xef instead
     wif: 0xb0,
     coin: coins.LTC
   },

--- a/test/networks.js
+++ b/test/networks.js
@@ -67,6 +67,10 @@ describe('networks', function () {
     const network = networks[name]
 
     describe(`networks.${name}`, function () {
+      it('is valid network', function () {
+        assert(coins.isValidNetwork(network))
+      })
+
       it('has expected properties', function () {
         assert.strictEqual(typeof network, 'object')
         assert.strictEqual(typeof network.messagePrefix, 'string')

--- a/test/networks.js
+++ b/test/networks.js
@@ -71,6 +71,26 @@ describe('networks', function () {
         assert(coins.isValidNetwork(network))
       })
 
+      it('getNetworkName() returns network name', function () {
+        assert.strictEqual(name, coins.getNetworkName(network))
+      })
+
+      it('has corresponding testnet/mainnet', function () {
+        if (coins.isMainnet(network)) {
+          assert.strictEqual(coins.isTestnet(network), false)
+          assert.strictEqual(coins.getMainnet(network), network)
+          assert.strictEqual(
+            typeof coins.getTestnet(network),
+            (network === networks.bitcoingold) ? 'undefined' : 'object'
+          )
+        } else {
+          assert.strictEqual(coins.isMainnet(network), false)
+          assert.strictEqual(coins.getTestnet(network), network)
+          assert.notStrictEqual(coins.getMainnet(network), network)
+          assert.strictEqual(typeof coins.getMainnet(network), 'object')
+        }
+      })
+
       it('has expected properties', function () {
         assert.strictEqual(typeof network, 'object')
         assert.strictEqual(typeof network.messagePrefix, 'string')
@@ -80,6 +100,25 @@ describe('networks', function () {
         assert.strictEqual(typeof network.scriptHash, 'number')
         assert.strictEqual(typeof network.wif, 'number')
         assert.strictEqual(typeof network.coin, 'string')
+
+        // FIXME(BG-16466): litecoin should not be a special case here -- all forks have the same bip32 values
+        const isLitecoin = coins.getMainnet(network) === networks.litecoin
+
+        if (coins.isMainnet(network)) {
+          assert.strictEqual(
+            (network.bip32.public === networks.bitcoin.bip32.public), !isLitecoin
+          )
+          assert.strictEqual(
+            (network.bip32.private === networks.bitcoin.bip32.private), !isLitecoin
+          )
+        } else {
+          assert.strictEqual(
+            (network.bip32.public === networks.testnet.bip32.public), !isLitecoin
+          )
+          assert.strictEqual(
+            (network.bip32.private === networks.testnet.bip32.private), !isLitecoin
+          )
+        }
       })
 
       for (const otherName in networks) {

--- a/test/networks.js
+++ b/test/networks.js
@@ -1,0 +1,118 @@
+/* global describe, it */
+const assert = require('assert')
+
+const { networks, coins } = require('../src')
+
+describe('networks', function () {
+  // Ideally, all properties for all coins should be distinct.
+  // However, there are some exceptions and some networks share the same properties.
+
+  // Here we define some groups of networks that are allowed to share properties.
+  const bitcoinSharedMessagePrefix = [
+    'bitcoin', 'testnet',
+    'bitcoincash', 'bitcoincashTestnet',
+    'bitcoinsv', 'bitcoinsvTestnet'
+  ]
+
+  const bitcoinMainnetSharedPubkeyPrefix = [
+    'bitcoin',
+    'bitcoincash',
+    'bitcoinsv'
+  ]
+
+  const bitcoinMainnetSharedScriptPrefix = bitcoinMainnetSharedPubkeyPrefix.filter(() => true)
+
+  const bitcoinTestnetSharedPubkeyPrefix = [
+    'testnet',
+    'bitcoincashTestnet',
+    'bitcoinsvTestnet',
+    'litecoinTest'
+  ]
+
+  const bitcoinTestnetSharedScriptPrefix = bitcoinTestnetSharedPubkeyPrefix.filter(n => n !== 'litecoinTest')
+
+  const bitcoinMainnetSharedWIFPrefix = [
+    'bitcoin',
+    'bitcoincash',
+    'bitcoingold',
+    'bitcoinsv',
+    'zcash'
+  ]
+
+  const bitcoinTestnetSharedWIFPrefix = [
+    'testnet',
+    'bitcoincashTestnet',
+    'bitcoinsvTestnet',
+    'dashTest',
+    'zcashTest'
+  ]
+
+  // FIXME(BG-16466): this is a bug, they should be distinct
+  const litecoinSharedWIFPrefix = [
+    'litecoin',
+    'litecoinTest'
+  ]
+
+  const bech32Coins = [
+    'bitcoin', 'testnet',
+    'bitcoingold',
+    'litecoin', 'litecoinTest'
+  ]
+
+  function sameGroup (group, name, otherName) {
+    return group.includes(name) && group.includes(otherName)
+  }
+
+  for (const name in networks) {
+    const network = networks[name]
+
+    describe(`networks.${name}`, function () {
+      it('has expected properties', function () {
+        assert.strictEqual(typeof network, 'object')
+        assert.strictEqual(typeof network.messagePrefix, 'string')
+        assert.strictEqual(typeof network.bech32, bech32Coins.includes(name) ? 'string' : 'undefined')
+        assert.strictEqual(typeof network.bip32, 'object')
+        assert.strictEqual(typeof network.pubKeyHash, 'number')
+        assert.strictEqual(typeof network.scriptHash, 'number')
+        assert.strictEqual(typeof network.wif, 'number')
+        assert.strictEqual(typeof network.coin, 'string')
+      })
+
+      for (const otherName in networks) {
+        if (name === otherName) {
+          continue
+        }
+
+        it(`has distinct properties with ${otherName}`, function () {
+          const otherNetwork = networks[otherName]
+
+          assert.strictEqual(
+            (network.messagePrefix === otherNetwork.messagePrefix),
+            (network.coin === otherNetwork.coin) ||
+            sameGroup(bitcoinSharedMessagePrefix, name, otherName)
+          )
+
+          assert.strictEqual(
+            (network.pubKeyHash === otherNetwork.pubKeyHash),
+            sameGroup(bitcoinMainnetSharedPubkeyPrefix, name, otherName) ||
+            sameGroup(bitcoinTestnetSharedPubkeyPrefix, name, otherName)
+          )
+
+          assert.strictEqual(
+            (network.scriptHash === otherNetwork.scriptHash),
+            sameGroup(bitcoinMainnetSharedScriptPrefix, name, otherName) ||
+            sameGroup(bitcoinTestnetSharedScriptPrefix, name, otherName)
+          )
+
+          assert.strictEqual(
+            (network.wif === otherNetwork.wif),
+            sameGroup(bitcoinMainnetSharedWIFPrefix, name, otherName) ||
+            sameGroup(bitcoinTestnetSharedWIFPrefix, name, otherName) ||
+            // FIXME(BG-16466): this group should not exist
+            sameGroup(litecoinSharedWIFPrefix, name, otherName)
+          )
+        })
+      }
+    })
+  }
+})


### PR DESCRIPTION
See individual commits

00d19ce
   src/coins.js: add getMainnet/getTestnet

   These methods are useful when grouping tests

3e22726
   src/coins.js: add isDash to isValidNetwork

99c7060
   src/coins.js: isValidCoin -> isValidNetwork

   The function takes `network` as an argument after all.

   Add deprecation notice for old func.

b75742a
   src/networks.js: add tests

   Make sure values are distinct unless explicitly grouped.

   This method uncovered bug BG-16466.

   Issue: BG-16465

06f0b92
   src/networks.js: define coin network names

   We need to describe some more relationships between networks. For instance,
   it is very useful to define `getMainnet(network)` and
   `getTestnet(network)`.

   These methods would fit well in `coins.js` and can be implemented using
   object equality on the constants defined in `network.js`. However,
   importing `network.js` from `coins.js` would lead to a circular import.

   This change allows using `coin.js` to contain utility methods for
   `network.js` without having circular import problems.