### PR TITLE
update blake2b to master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bitgo-utxo-lib",
+  "name": "@bitgo/utxo-lib",
   "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -351,8 +351,8 @@
       "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
     },
     "blake2b": {
-      "version": "git+https://github.com/BitGo/blake2b.git#6268e6dd678661e0acc4359e9171b97eb1ebf8ac",
-      "from": "git+https://github.com/BitGo/blake2b.git#6268e6dd678661e0acc4359e9171b97eb1ebf8ac",
+      "version": "git+https://github.com/BitGo/blake2b.git#5e4fce2d457589913180c5dbf6f7e23a0c9ff84c",
+      "from": "git+https://github.com/BitGo/blake2b.git#5e4fce2d457589913180c5dbf6f7e23a0c9ff84c",
       "requires": {
         "blake2b-wasm": "git+https://github.com/BitGo/blake2b-wasm.git#193cdb71656c1a6c7f89b05d0327bb9b758d071b",
         "nanoassert": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "bigi": "^1.4.0",
     "bip66": "^1.1.0",
     "bitcoin-ops": "^1.3.0",
-    "blake2b": "https://github.com/BitGo/blake2b#6268e6dd678661e0acc4359e9171b97eb1ebf8ac",
+    "blake2b": "https://github.com/BitGo/blake2b#5e4fce2d457589913180c5dbf6f7e23a0c9ff84c",
     "bs58check": "^2.0.0",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.3",


### PR DESCRIPTION
Updates the version of Blake2b to the one that includes a package-lock file, from this PR:
https://github.com/BitGo/blake2b/pull/1