### PR TITLE
Bg 24753 remove branch id check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitgo-utxo-lib",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "engines": {

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -533,9 +533,6 @@ TransactionBuilder.prototype.setConsensusBranchId = function (consensusBranchId)
   if (!coins.isZcash(this.network)) {
     throw new Error('consensusBranchId can only be set for Zcash transactions')
   }
-  if (!this.inputs.every(function (input) { return input.signatures === undefined })) {
-    throw new Error('Changing the consensusBranchId for a partially signed transaction would invalidate signatures')
-  }
   typeforce(types.UInt32, consensusBranchId)
   this.tx.consensusBranchId = consensusBranchId
 }


### PR DESCRIPTION
see https://github.com/BitGo/bitgo-utxo-lib/pull/89#discussion_r506369556

It should be OK to call this method even if a TX already has
a signature. (Re-)setting the value does not alter the TX message
digest and so it does not invalidate any existing signatures (the way
changing the TX's `locktime` would). The caller of course must be
sure to only set the consensusBranchId that is valid for the current
network, and there is only one valid option per network.

Removing this check is required in downstream settings where an
application uses this library to add multiple signatures to a
multisig input and needs to overide the default consensusBranchId
each time.

TICKET BG-24753